### PR TITLE
Добавить графики на вкладку «Прогнозирование»

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -136,12 +136,21 @@ def sales_analysis() -> dict:
 @app.get("/api/forecast")
 def forecast() -> dict:
     return {
-        "period": "30 дней",
+        "period": "6 месяцев",
+        "labels": ["Янв", "Фев", "Мар", "Апр", "Май", "Июн"],
         "kpis": {
             "revenue": {"value": "1 250 000 ₽", "delta": "+12%"},
             "orders": {"value": "6 420", "delta": "+15%"},
             "avgCheck": {"value": "195 ₽", "delta": "-8%"},
         },
+        "revenueSeries": [
+            {"name": "Фактическая выручка", "values": [920, 1030, 980, 1220, 1160, 1250], "color": "#3b82f6"},
+            {"name": "Прогнозируемая выручка", "values": [900, 1010, 1020, 1180, 1190, 1270], "color": "#f59e0b"},
+        ],
+        "ordersSeries": [
+            {"name": "Фактические заказы", "values": [5100, 5400, 5000, 6100, 5900, 6420], "color": "#10b981"},
+            {"name": "Прогноз заказов", "values": [5000, 5350, 5200, 6000, 6100, 6500], "color": "#a855f7"},
+        ],
     }
 
 

--- a/frontend/src/components/LineChart.jsx
+++ b/frontend/src/components/LineChart.jsx
@@ -1,0 +1,76 @@
+const DEFAULT_COLORS = ['#3b82f6', '#f59e0b'];
+
+export default function LineChart({ labels = [], series = [] }) {
+  if (!labels.length || !series.length) {
+    return <p>Недостаточно данных для графика.</p>;
+  }
+
+  const width = 760;
+  const height = 280;
+  const padding = { top: 20, right: 16, bottom: 40, left: 44 };
+
+  const allValues = series.flatMap((item) => item.values);
+  const minValue = Math.min(...allValues);
+  const maxValue = Math.max(...allValues);
+  const range = maxValue - minValue || 1;
+
+  const chartWidth = width - padding.left - padding.right;
+  const chartHeight = height - padding.top - padding.bottom;
+
+  const xStep = labels.length > 1 ? chartWidth / (labels.length - 1) : 0;
+  const yTicks = 5;
+
+  const getX = (index) => padding.left + index * xStep;
+  const getY = (value) => padding.top + ((maxValue - value) / range) * chartHeight;
+
+  const buildPath = (values) => values.map((value, index) => `${index === 0 ? 'M' : 'L'} ${getX(index)} ${getY(value)}`).join(' ');
+
+  return (
+    <div className="line-chart">
+      <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label="Линейный график">
+        {Array.from({ length: yTicks + 1 }).map((_, index) => {
+          const tickValue = minValue + (range / yTicks) * index;
+          const y = getY(tickValue);
+          return (
+            <g key={`y-${index}`}>
+              <line x1={padding.left} y1={y} x2={width - padding.right} y2={y} className="chart-grid-line" />
+              <text x={padding.left - 8} y={y + 4} className="chart-axis-label" textAnchor="end">
+                {Math.round(tickValue)}
+              </text>
+            </g>
+          );
+        })}
+
+        {labels.map((label, index) => (
+          <text key={label} x={getX(index)} y={height - 14} className="chart-axis-label" textAnchor="middle">
+            {label}
+          </text>
+        ))}
+
+        {series.map((item, idx) => {
+          const color = item.color || DEFAULT_COLORS[idx % DEFAULT_COLORS.length];
+          return (
+            <g key={item.name}>
+              <path d={buildPath(item.values)} fill="none" stroke={color} strokeWidth="2.5" strokeLinecap="round" />
+              {item.values.map((value, index) => (
+                <circle key={`${item.name}-${index}`} cx={getX(index)} cy={getY(value)} r="3" fill={color} />
+              ))}
+            </g>
+          );
+        })}
+      </svg>
+
+      <div className="chart-legend">
+        {series.map((item, idx) => {
+          const color = item.color || DEFAULT_COLORS[idx % DEFAULT_COLORS.length];
+          return (
+            <span key={`legend-${item.name}`}>
+              <i style={{ backgroundColor: color }} />
+              {item.name}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ForecastPage.jsx
+++ b/frontend/src/pages/ForecastPage.jsx
@@ -1,27 +1,46 @@
 import { useEffect, useState } from 'react';
 import { apiGet } from '../api';
+import LineChart from '../components/LineChart';
 
 export default function ForecastPage() {
   const [data, setData] = useState(null);
+
   useEffect(() => {
     apiGet('/forecast').then(setData);
   }, []);
+
   if (!data) return <p>Загрузка...</p>;
 
   return (
     <section>
       <h1>Прогнозирование</h1>
       <p>Период анализа: {data.period}</p>
+
       <div className="grid three">
         <Metric name="Выручка" {...data.kpis.revenue} />
         <Metric name="Заказы" {...data.kpis.orders} />
         <Metric name="Средний чек" {...data.kpis.avgCheck} />
       </div>
-      <div className="card"><p>График прогнозных данных (заглушка) по выручке, заказам и среднему чеку.</p></div>
+
+      <div className="card">
+        <h3>Тренд выручки: Факт vs Прогноз</h3>
+        <LineChart labels={data.labels} series={data.revenueSeries} />
+      </div>
+
+      <div className="card">
+        <h3>Тренд заказов: Факт vs Прогноз</h3>
+        <LineChart labels={data.labels} series={data.ordersSeries} />
+      </div>
     </section>
   );
 }
 
 function Metric({ name, value, delta }) {
-  return <div className="card stat"><h4>{name}</h4><strong>{value}</strong><small>{delta}</small></div>;
+  return (
+    <div className="card stat">
+      <h4>{name}</h4>
+      <strong>{value}</strong>
+      <small>{delta}</small>
+    </div>
+  );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -26,3 +26,47 @@ th, td { border-bottom: 1px solid #e5e7eb; text-align: left; padding: 12px; }
   .grid.four, .grid.three { grid-template-columns: 1fr; }
   .sidebar { width: 180px; }
 }
+
+.line-chart {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.line-chart svg {
+  width: 100%;
+  min-width: 640px;
+  height: auto;
+}
+
+.chart-grid-line {
+  stroke: #e5e7eb;
+  stroke-width: 1;
+}
+
+.chart-axis-label {
+  fill: #6b7280;
+  font-size: 11px;
+}
+
+.chart-legend {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 8px;
+  color: #4b5563;
+  font-size: 13px;
+}
+
+.chart-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.chart-legend i {
+  width: 14px;
+  height: 3px;
+  border-radius: 999px;
+  display: inline-block;
+}


### PR DESCRIPTION
### Motivation
- Во вкладке «Прогнозирование» была текстовая заглушка вместо графиков, из-за чего раздел не соответствовал макету с KPI и трендовыми графиками.
- Нужно показать тренды «факт vs прогноз» для выручки и заказов и предоставить данные API для визуализации.

### Description
- Добавлен переиспользуемый SVG-компонент `LineChart` в `frontend/src/components/LineChart.jsx` для отрисовки осей, сетки, линий, точек и легенды.  
- На странице `frontend/src/pages/ForecastPage.jsx` заменена текстовая заглушка на карточки с двумя графиками, использующими `LineChart` для `revenueSeries` и `ordersSeries`.  
- Расширен API-ответ `/api/forecast` в `backend/main.py`, добавлены поля `labels`, `revenueSeries` и `ordersSeries` с примерными значениями для построения графиков.  
- Добавлены стили для графиков и легенды в `frontend/src/styles.css` (адаптивная ширина SVG, оформление сетки и легенды).

### Testing
- `python -m py_compile backend/main.py` — успешно выполнена проверка синтаксиса Python.  
- `cd frontend && npm install` — неуспешно из-за ошибки 403 от npm registry в текущем окружении, поэтому фронтенд-бандл не собирался.  
- Попытка сделать скриншот страницы через Playwright (`http://127.0.0.1:5173/forecast`) завершилась с `ERR_EMPTY_RESPONSE`, так как локальный фронтенд-сервер не был поднят без установки npm-зависимостей.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e4db64e88328a4a39219ce4f860d)