### PR TITLE
Add ELK-style centralized logging for frontend and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ docker compose up --build
 - Backend DB health: `http://localhost:8000/api/health/db`
 - Postgres: `localhost:5432` (параметры из `.env`)
 - pgAdmin: `http://localhost:5050` (параметры из `.env`)
+- Elasticsearch: `http://localhost:9200`
+- Kibana: `http://localhost:5601`
 
 Остановка:
 
@@ -70,3 +72,25 @@ docker compose down
 - `GET /api/forecast`
 - `GET /api/alerts`
 - `GET /api/users`
+
+## Логирование в стиле ELK
+
+В проект добавлена централизованная схема логирования для backend и frontend:
+
+- Backend пишет структурированные JSON-логи (stdout + Elasticsearch индекс `egypt-logs-YYYY.MM.DD`).
+- Frontend отправляет клиентские ошибки и события в `POST /api/logs/frontend`.
+- Kibana читает логи из Elasticsearch для поиска и построения дашбордов.
+
+### Что уже логируется
+
+- Все HTTP-запросы backend (метод, путь, статус, длительность, IP).
+- Ошибки backend с traceback.
+- Ошибки frontend: `window.onerror`, `unhandledrejection`.
+- Ошибки API-запросов и события входа из frontend.
+
+### Быстрый старт в Kibana
+
+1. Откройте `http://localhost:5601`.
+2. Перейдите в **Stack Management → Data Views**.
+3. Создайте Data View с шаблоном `egypt-logs-*`.
+4. Используйте поле времени `@timestamp`.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,7 +8,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY main.py db.py ./
+COPY main.py db.py logging_setup.py ./
 COPY services ./services
 
 EXPOSE 8000

--- a/backend/logging_setup.py
+++ b/backend/logging_setup.py
@@ -1,0 +1,131 @@
+import json
+import logging
+import os
+import socket
+import time
+import uuid
+from datetime import datetime, timezone
+from urllib import error, request
+
+from fastapi import Request
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "@timestamp": datetime.now(timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "service": "egypt-backend",
+            "environment": os.getenv("APP_ENV", "local"),
+            "host": socket.gethostname(),
+        }
+
+        if hasattr(record, "event_type"):
+            payload["event_type"] = record.event_type
+        if hasattr(record, "request_id"):
+            payload["request_id"] = record.request_id
+        if hasattr(record, "method"):
+            payload["method"] = record.method
+        if hasattr(record, "path"):
+            payload["path"] = record.path
+        if hasattr(record, "status_code"):
+            payload["status_code"] = record.status_code
+        if hasattr(record, "duration_ms"):
+            payload["duration_ms"] = record.duration_ms
+        if hasattr(record, "client_ip"):
+            payload["client_ip"] = record.client_ip
+        if hasattr(record, "frontend"):
+            payload["frontend"] = record.frontend
+
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+
+        return json.dumps(payload, ensure_ascii=False)
+
+
+class ElasticsearchHandler(logging.Handler):
+    def __init__(self, base_url: str, index_prefix: str = "egypt-logs"):
+        super().__init__()
+        self.base_url = base_url.rstrip("/")
+        self.index_prefix = index_prefix
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            data = self.format(record)
+            day = datetime.now(timezone.utc).strftime("%Y.%m.%d")
+            index_name = f"{self.index_prefix}-{day}"
+            req = request.Request(
+                url=f"{self.base_url}/{index_name}/_doc",
+                data=data.encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            request.urlopen(req, timeout=0.5).read()
+        except Exception:
+            self.handleError(record)
+
+
+def setup_logging() -> None:
+    logger = logging.getLogger("egypt")
+    if logger.handlers:
+        return
+
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    formatter = JsonFormatter()
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    elastic_url = os.getenv("ELASTICSEARCH_URL")
+    if elastic_url:
+        elastic_handler = ElasticsearchHandler(elastic_url)
+        elastic_handler.setLevel(logging.INFO)
+        elastic_handler.setFormatter(formatter)
+        logger.addHandler(elastic_handler)
+
+
+def get_logger() -> logging.Logger:
+    return logging.getLogger("egypt")
+
+
+async def log_request(request: Request, call_next):
+    logger = get_logger()
+    request_id = str(uuid.uuid4())
+    start = time.perf_counter()
+
+    try:
+        response = await call_next(request)
+        duration_ms = round((time.perf_counter() - start) * 1000, 2)
+        logger.info(
+            "HTTP request",
+            extra={
+                "event_type": "backend.http",
+                "request_id": request_id,
+                "method": request.method,
+                "path": request.url.path,
+                "status_code": response.status_code,
+                "duration_ms": duration_ms,
+                "client_ip": request.client.host if request.client else None,
+            },
+        )
+        response.headers["X-Request-ID"] = request_id
+        return response
+    except Exception:
+        duration_ms = round((time.perf_counter() - start) * 1000, 2)
+        logger.exception(
+            "HTTP request failed",
+            extra={
+                "event_type": "backend.http.error",
+                "request_id": request_id,
+                "method": request.method,
+                "path": request.url.path,
+                "duration_ms": duration_ms,
+                "client_ip": request.client.host if request.client else None,
+            },
+        )
+        raise

--- a/backend/logging_setup.py
+++ b/backend/logging_setup.py
@@ -5,7 +5,7 @@ import socket
 import time
 import uuid
 from datetime import datetime, timezone
-from urllib import error, request
+from urllib import request
 
 from fastapi import Request
 
@@ -64,7 +64,9 @@ class ElasticsearchHandler(logging.Handler):
             )
             request.urlopen(req, timeout=0.5).read()
         except Exception:
-            self.handleError(record)
+            # Elasticsearch transport is best-effort: do not break request flow
+            # and do not spam stderr with Python logging internal tracebacks.
+            return
 
 
 def setup_logging() -> None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,21 @@
+from datetime import datetime
+from typing import Literal
+
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from db import fetch_all, fetch_one
+from logging_setup import get_logger, log_request, setup_logging
 from services import AnalyticsService
+
+setup_logging()
+logger = get_logger()
 
 app = FastAPI(title="AI Retail Analytics API", version="1.0.0")
 analytics_service = AnalyticsService()
+
+app.middleware("http")(log_request)
 
 app.add_middleware(
     CORSMiddleware,
@@ -20,6 +29,15 @@ app.add_middleware(
 class LoginRequest(BaseModel):
     username: str
     password: str
+
+
+class FrontendLog(BaseModel):
+    level: Literal["info", "warn", "error"]
+    message: str
+    page: str | None = None
+    userAgent: str | None = None
+    metadata: dict = Field(default_factory=dict)
+    timestamp: datetime | None = None
 
 
 @app.get("/health")
@@ -46,6 +64,25 @@ def login(payload: LoginRequest) -> dict:
             "dashboardPath": "/dashboard",
         }
     raise HTTPException(status_code=401, detail="Неверные учетные данные")
+
+
+@app.post("/api/logs/frontend")
+def ingest_frontend_log(payload: FrontendLog) -> dict:
+    logger.info(
+        "Frontend log event",
+        extra={
+            "event_type": "frontend.log",
+            "frontend": {
+                "level": payload.level,
+                "message": payload.message,
+                "page": payload.page,
+                "user_agent": payload.userAgent,
+                "metadata": payload.metadata,
+                "timestamp": payload.timestamp.isoformat() if payload.timestamp else None,
+            },
+        },
+    )
+    return {"status": "accepted"}
 
 
 @app.get("/api/dashboard")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,15 +34,43 @@ services:
       - pgadmin_data:/var/lib/pgadmin
     restart: unless-stopped
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
+    container_name: egypt-elasticsearch
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+    volumes:
+      - elasticsearch_data:/usr/share/elasticsearch/data
+    restart: unless-stopped
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.15.0
+    container_name: egypt-kibana
+    environment:
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+    depends_on:
+      - elasticsearch
+    ports:
+      - "5601:5601"
+    restart: unless-stopped
+
   backend:
     build:
       context: ./backend
     container_name: egypt-backend
     environment:
       DATABASE_URL: ${DATABASE_URL}
+      APP_ENV: ${APP_ENV:-docker}
+      ELASTICSEARCH_URL: ${ELASTICSEARCH_URL:-http://elasticsearch:9200}
     depends_on:
       postgres:
         condition: service_healthy
+      elasticsearch:
+        condition: service_started
     ports:
       - "8000:8000"
     restart: unless-stopped
@@ -60,3 +88,4 @@ services:
 volumes:
   postgres_data:
   pgadmin_data:
+  elasticsearch_data:

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,3 +1,5 @@
+import { frontendLog } from './logger';
+
 const API_URL = import.meta.env.VITE_API_URL || '/api';
 
 export async function apiGet(path, params) {
@@ -12,8 +14,13 @@ export async function apiGet(path, params) {
 
   const response = await fetch(url.pathname + url.search);
   if (!response.ok) {
+    frontendLog('warn', `API GET failed: ${path}`, {
+      status: response.status,
+      query: Object.fromEntries(url.searchParams.entries()),
+    });
     throw new Error(`API ${path} failed`);
   }
+
   return response.json();
 }
 
@@ -23,8 +30,12 @@ export async function login(username, password) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username, password }),
   });
+
   if (!response.ok) {
+    frontendLog('warn', 'Login failed', { status: response.status, username });
     throw new Error('Ошибка входа');
   }
+
+  frontendLog('info', 'User login success', { username });
   return response.json();
 }

--- a/frontend/src/logger.js
+++ b/frontend/src/logger.js
@@ -1,0 +1,47 @@
+const LOG_ENDPOINT = import.meta.env.VITE_LOG_ENDPOINT || '/api/logs/frontend';
+
+function sendLog(payload) {
+  const body = JSON.stringify({
+    ...payload,
+    page: window.location.pathname,
+    userAgent: navigator.userAgent,
+    timestamp: new Date().toISOString(),
+  });
+
+  if (navigator.sendBeacon) {
+    const blob = new Blob([body], { type: 'application/json' });
+    navigator.sendBeacon(LOG_ENDPOINT, blob);
+    return;
+  }
+
+  fetch(LOG_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+    keepalive: true,
+  }).catch(() => {
+    // Ignore logger transport errors to avoid recursive logging.
+  });
+}
+
+export function frontendLog(level, message, metadata = {}) {
+  sendLog({ level, message, metadata });
+}
+
+export function setupFrontendErrorLogging() {
+  window.addEventListener('error', (event) => {
+    frontendLog('error', event.message || 'Unhandled error', {
+      source: event.filename,
+      line: event.lineno,
+      column: event.colno,
+      stack: event.error?.stack,
+    });
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    frontendLog('error', 'Unhandled promise rejection', {
+      reason: event.reason?.message || String(event.reason),
+      stack: event.reason?.stack,
+    });
+  });
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './styles.css';
+import { setupFrontendErrorLogging } from './logger';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
@@ -11,3 +12,5 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     </BrowserRouter>
   </React.StrictMode>
 );
+
+setupFrontendErrorLogging();


### PR DESCRIPTION
### Motivation
- Добавить централизованное структурированное логирование (в стиле ELK) чтобы собирать и анализировать логи фронта и бэка в едином месте. 
- Обеспечить трассировку HTTP-запросов и клиентских ошибок для ускорения отладки и мониторинга производительности.

### Description
- Добавлен модуль `backend/logging_setup.py` с JSON-форматтером, middleware для логирования HTTP-запросов и опциональным `ElasticsearchHandler`, который шлет логи по `ELASTICSEARCH_URL` в индекс `egypt-logs-YYYY.MM.DD`.
- Подключено логирование в `backend/main.py`, добавлен endpoint `POST /api/logs/frontend` и `app.middleware("http")(log_request)` для автоматической записи запросов; вызов `setup_logging()` и `get_logger()` интегрированы в приложение.
- На фронтенде добавлен `frontend/src/logger.js` с отправкой через `navigator.sendBeacon`/`fetch`, включён перехват `window.onerror` и `unhandledrejection`, и интеграция логирования в `frontend/src/api.js` и `frontend/src/main.jsx`.
- Обновлён `docker-compose.yml` для запуска `elasticsearch` и `kibana`, добавлена переменная окружения `ELASTICSEARCH_URL` для backend, и обновлён `README.md` с инструкцией по созданию Data View `egypt-logs-*` в Kibana.

### Testing
- Выполнена компиляция Python-модулей командой `python -m compileall backend` и ошибок компиляции не обнаружено. (успешно)
- Запущены unit-тесты бекенда командой `pytest -q` и все тесты прошли: `5 passed`. (успешно)
- Собран фронтенд командой `npm run build` и сборка завершилась успешно. (успешно)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b733d3939c83288e3601af7d128063)